### PR TITLE
fix: Use generated path from git clone as target

### DIFF
--- a/lib/skeleton-dir.js
+++ b/lib/skeleton-dir.js
@@ -26,7 +26,7 @@ function resolveRepo(supplier) {
 }
 
 async function finalFolder(target, generate) {
-  await generate(target);
+  target = await generate(target);
 
   const files = fs.readdirSync(target).filter(n => n !== '.keep');
   if (files.length === 1) {


### PR DESCRIPTION
When using a private GitLab repository e.g. `git+ssh://git@gitlab.com:my-org/my-project.git`
the clone is performed correctly but `finalFolder(target, generate)` returns the wrong path, e.g.
 `/tmp/tmp-73792-2hsN3OqRrsZG/gitlab.commy-org`
 instead of
` /tmp/tmp-73792-2hsN3OqRrsZG/gitlab.commy-org/my-project`

This causes that the `npm i --only=prod` is not executed, since no `package.json` is found.
Therefore the whole makes for such projects does not work. 

Occurs since Version 2.1.4, worked in version 2.1.3